### PR TITLE
Fix rotation of insect when moving backwards

### DIFF
--- a/src/godot/scripts/bug.gd
+++ b/src/godot/scripts/bug.gd
@@ -26,7 +26,13 @@ func _physics_process(delta: float) -> void:
 		velocity += transform.basis.x * speed
 	
 	# Handles rotating the bug when pressing left or right arrow key	
-	if Input.is_action_pressed("ui_left"):
+	if Input.is_action_pressed("ui_left") and Input.is_action_pressed("ui_down"):
+		rotate_y(-lerp(0, spin, lerp_spin_speed))
+		is_rotating = true
+	elif Input.is_action_pressed("ui_left"):
+		rotate_y(lerp(0, spin, lerp_spin_speed))
+		is_rotating = true
+	elif Input.is_action_pressed("ui_right") and Input.is_action_pressed("ui_down"):
 		rotate_y(lerp(0, spin, lerp_spin_speed))
 		is_rotating = true
 	elif Input.is_action_pressed("ui_right"):


### PR DESCRIPTION
When pressing the left arrow key and the down arrow key at once, the insect was rotating to the left (should be to the right). Add two if-statements to check for left/right and down arrow keys being pressed and flip the rotation when this occurs.