### PR TITLE
Reset number of passwords when restarting the game

### DIFF
--- a/src/godot/scripts/CounterPasswords.gd
+++ b/src/godot/scripts/CounterPasswords.gd
@@ -1,6 +1,7 @@
 extends Label
 
 func _ready():
+	global.collected_passwords = 0
 	set_text_passwords()
 
 func _on_password_collected():

--- a/src/godot/scripts/CounterPasswords.gd
+++ b/src/godot/scripts/CounterPasswords.gd
@@ -1,9 +1,12 @@
 extends Label
 
 func _ready():
-	global.collected_passwords = 0
+	reset_collected_passwords()
 	set_text_passwords()
 
+func reset_collected_passwords():
+	global.collected_passwords = 0
+	
 func _on_password_collected():
 	global.collected_passwords += 1	
 	set_text_passwords()


### PR DESCRIPTION
The number of passwords weren't resetted when restarting the game from the pause menu. This lead to a bug where there might be more passwords collected than there are in total (for example "Passwords: 21/20") See #8 for screenshots and a full description. Closes #8.